### PR TITLE
use lintr bot - should pass CI

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,1 +1,7 @@
-inst/.lintr
+linters: with_defaults(
+  commented_code_linter = NULL,
+  line_length_linter(80),
+  object_length_linter(40),
+  open_curly_linter = NULL,
+  spaces_left_parentheses_linter = NULL
+  )

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ cache: packages
 
 bioc_required: true
 use_bioc: true
+
+env:
+- LINTR_COMMENT_BOT=true

--- a/inst/.lintr
+++ b/inst/.lintr
@@ -1,7 +1,0 @@
-linters: with_defaults(
-  commented_code_linter = NULL,
-  line_length_linter(80),
-  object_length_linter(40),
-  open_curly_linter = NULL,
-  spaces_left_parentheses_linter = NULL
-  )


### PR DESCRIPTION
Modifications to get R CMD check to pass:
- .lintr was removed
- .inst/lintr was moved to .lintr
- .inst/ was removed (empty dir inst/ threw a warning in R CMD check, despite .lintr being within that dir)

Modifications to ensure linting is still done on travis_CI:
- allowed LINTR_COMMENT_BOT to check my uploads
