### PR TITLE
comment lines should not be included at import

### DIFF
--- a/R/dupree_code_enumeration.R
+++ b/R/dupree_code_enumeration.R
@@ -131,10 +131,15 @@ get_source_expressions <- function(file) {
   }
 }
 
-import_parsed_code_blocks_from_single_file <- function(file) {
+#' import_parsed_code_blocks_from_one_file
+#'
+#' @importFrom   dplyr         filter_
+#'
+import_parsed_code_blocks_from_one_file <- function(file) {
   file %>%
     get_source_expressions() %>%
-    get_localised_parsed_code_blocks()
+    get_localised_parsed_code_blocks() %>%
+    dplyr::filter_(~ !token %in% "COMMENT")
 }
 
 #' @importFrom   dplyr         bind_rows
@@ -142,7 +147,7 @@ import_parsed_code_blocks_from_single_file <- function(file) {
 #'
 import_parsed_code_blocks <- function(files) {
   files %>%
-    purrr::map(import_parsed_code_blocks_from_single_file) %>%
+    purrr::map(import_parsed_code_blocks_from_one_file) %>%
     dplyr::bind_rows()
 }
 


### PR DESCRIPTION
Filtered any COMMENT blocks out during
`import_parsed_code_blocks_from_one_file`.

This ensured a failing test now passes.

Note that `....from_one_file` was previously `...from_single_file`.