### PR TITLE
fix #17 - increase default min-block-size to 20

### DIFF
--- a/R/dupree.R
+++ b/R/dupree.R
@@ -39,7 +39,7 @@
 #'
 #' @export
 
-dupree <- function(files, min_block_size = 5, ...) {
+dupree <- function(files, min_block_size = 20, ...) {
   preprocess_code_blocks(files, min_block_size) %>%
     find_best_matches()
 }
@@ -67,7 +67,7 @@ dupree <- function(files, min_block_size = 5, ...) {
 #' @export
 
 dupree_dir <- function(path,
-                       min_block_size = 5,
+                       min_block_size = 20,
                        filter = NULL,
                        ...,
                        recursive = TRUE) {
@@ -95,7 +95,7 @@ dupree_dir <- function(path,
 #' @export
 
 dupree_package <- function(package,
-                           min_block_size = 5) {
+                           min_block_size = 20) {
   dupree_dir(package, min_block_size, filter = paste0(package, "/R/"))
 }
 

--- a/R/dupree_code_enumeration.R
+++ b/R/dupree_code_enumeration.R
@@ -171,7 +171,7 @@ tokenize_code_blocks <- function(block_df) {
 #' @importFrom   methods       new
 #' @include      dupree_classes.R
 #'
-preprocess_code_blocks <- function(files, min_block_size = 5) {
+preprocess_code_blocks <- function(files, min_block_size = 20) {
   blocks <- files %>%
     import_parsed_code_blocks() %>%
     tokenize_code_blocks() %>%

--- a/man/dupree.Rd
+++ b/man/dupree.Rd
@@ -4,7 +4,7 @@
 \alias{dupree}
 \title{Newer version of the duplicate detection workflow}
 \usage{
-dupree(files, min_block_size = 5, ...)
+dupree(files, min_block_size = 20, ...)
 }
 \arguments{
 \item{files}{A set of files over which code-duplication

--- a/man/dupree_dir.Rd
+++ b/man/dupree_dir.Rd
@@ -4,7 +4,8 @@
 \alias{dupree_dir}
 \title{`dupree_dir` - run duplicate-code detection over all R-files in a directory}
 \usage{
-dupree_dir(path, min_block_size = 5, filter = NULL, ..., recursive = TRUE)
+dupree_dir(path, min_block_size = 20, filter = NULL, ...,
+  recursive = TRUE)
 }
 \arguments{
 \item{path}{A directory. All files in this directory that

--- a/man/dupree_package.Rd
+++ b/man/dupree_package.Rd
@@ -5,7 +5,7 @@
 \title{`dupree_package` - run duplicate-code detection over all files in a
 package's `R` directory}
 \usage{
-dupree_package(package, min_block_size = 5)
+dupree_package(package, min_block_size = 20)
 }
 \arguments{
 \item{package}{The name or path to the package that is to be


### PR DESCRIPTION
Min block size of 5 was too permissive - it resulted in too many blocks being compared. As a result many identical, but trivial, code blocks were identified with `min_block_size=5`.