### PR TITLE
export a '\value' block for `dupree()`

### DIFF
--- a/R/dupree.R
+++ b/R/dupree.R
@@ -10,7 +10,7 @@
 #     - drop any blocks that have fewer non-trivial symbols than some threshold
 # - enumerate the symbols
 # - construct a vector of enumerated-symbols for each code-block in each file
-# - run levenshtein distance between each pair of enumerated code blocks
+# - run levenshtein distance between each pair of enumerated code-blocks
 # - return the distance-sorted associations between blocks
 
 # Therefore, need class:
@@ -25,27 +25,27 @@
 
 #' Detect code duplication between the code-blocks in a set of files
 #'
-#' This function identifies all code blocks in a set of files and then computes
-#' a similarity score between those code blocks to help identify functions /
+#' This function identifies all code-blocks in a set of files and then computes
+#' a similarity score between those code-blocks to help identify functions /
 #' classes that have a high level of duplication, and could possibly be
 #' refactored.
 #'
-#' Code blocks under a size threshold are disregarded before analysis (the size
+#' Code-blocks under a size threshold are disregarded before analysis (the size
 #' threshold is controlled by \code{min_block_size}); and only top-level code
 #' blocks are considered.
 #'
-#' Every sufficiently large code block in the input files will be present in
+#' Every sufficiently large code-block in the input files will be present in
 #' the results at least once. If code-block X and code-block Y are present in
-#' a row of the resulting data-frame, then either X is the closest match to Y
+#' a row of the resulting data-frame, then either X is the closest match to Y,
 #' or Y is the closest match to X (or possibly both) according to the
-#' similarity score; as such some code blocks may be present multiple times in
+#' similarity score; as such, some code-blocks may be present multiple times in
 #' the results.
 #'
-#' Similarity between code blocks is calculated using the
+#' Similarity between code-blocks is calculated using the
 #' longest-common-subsequence (\code{lcs}) measure from the package
 #' \code{stringdist}. This measure is applied to a tokenised version of the
 #' code-blocks. That is, each function name / operator / variable in the code
-#' blocks is converted to a unique integer so that a code block can be
+#' blocks is converted to a unique integer so that a code-block can be
 #' represented as a vector of integers and the \code{lcs} measure is applied to
 #' each pair of these vectors.
 #'
@@ -61,19 +61,19 @@
 #'
 #' @param        ...           Unused at present.
 #'
-#' @value        A tibble. Each row in the table summarises the comparison
+#' @return        A tibble. Each row in the table summarises the comparison
 #' between two code-blocks (block 'a' and block 'b') in the input files. Each
-#' code block is indicated by: i) the file (file_a / file_b) that contains it;
-#' ii) its position within that file (block_a / block_b; 1 being the first
-#' code block in a given file); and iii) the line where that code block starts
-#' in that file (line_a / line_b). The pairs of code blocks are ordered
-#' according to a similarity score. Any match that is returned is either the
-#' top hit for block 'a' or for block 'b' (or both).
+#' code-block in the pair is indicated by: i) the file (file_a / file_b) that
+#' contains it; ii) its position within that file (block_a / block_b; 1 being
+#' the first code-block in a given file); and iii) the line where that
+#' code-block starts in that file (line_a / line_b). The pairs of code-blocks
+#' are ordered by decreasing similarity. Any match that is returned is either
+#' the top hit for block 'a' or for block 'b' (or both).
 #'
 #' @importFrom   magrittr      %>%
 #'
 #' @examples
-#' # To quantify duplication between the top-level code blocks in a file
+#' # To quantify duplication between the top-level code-blocks in a file
 #' example_file <- system.file("extdata", "duplicated.R", package = "dupree")
 #' dup <- dupree(example_file, min_block_size = 10)
 #' dup
@@ -83,8 +83,8 @@
 #' readLines(example_file)[dup$line_a[1] + c(0:3)]
 #' readLines(example_file)[dup$line_b[1] + c(0:3)]
 #'
-#' # The code blocks in the example file are rather small, so if
-#' # `min_block_size` is too large, none of the code blocks will be analysed
+#' # The code-blocks in the example file are rather small, so if
+#' # `min_block_size` is too large, none of the code-blocks will be analysed
 #' # and the results will be empty:
 #' dupree(example_file, min_block_size = 40)
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,16 @@
+## Resubmission
+This is the second resubmission of {dupree}. In this version I have:
+* Ensured the `\value` tag for function `dupree()` is present in `dupree.Rd`
+  (apologies, I had used an incorrect roxygen2 tag in the previous
+  resubmission).
+
+* Fixed some typos in the documentation.
+
+In the previous resubmission, I:
+
+* Added some examples to the documentation for `dupree::dupree` these use a
+  file that is stored in `inst/extdata` and accessed using `system.file()`
+
 ## Test environments
 * local Ubuntu (in conda envs), R 3.5.1 and R 3.6.1
 * Ubuntu 16.04 (on travis-ci.org), R 3.2.5, 3.3.3, 3.4.4, 3.5.3, 3.6.1 and devel

--- a/man/dupree.Rd
+++ b/man/dupree.Rd
@@ -19,44 +19,55 @@ measurement.}
 
 \item{...}{Unused at present.}
 }
+\value{
+A tibble. Each row in the table summarises the comparison
+between two code-blocks (block 'a' and block 'b') in the input files. Each
+code-block in the pair is indicated by: i) the file (file_a / file_b) that
+contains it; ii) its position within that file (block_a / block_b; 1 being
+the first code-block in a given file); and iii) the line where that
+code-block starts in that file (line_a / line_b). The pairs of code-blocks
+are ordered by decreasing similarity. Any match that is returned is either
+the top hit for block 'a' or for block 'b' (or both).
+}
 \description{
-This function identifies all code blocks in a set of files and then computes
-a similarity score between those code blocks to help identify functions /
+This function identifies all code-blocks in a set of files and then computes
+a similarity score between those code-blocks to help identify functions /
 classes that have a high level of duplication, and could possibly be
 refactored.
 }
 \details{
-Code blocks under a size threshold are disregarded before analysis (the size threshold is
-controlled by \code{min_block_size}); and only top-level code blocks are
-considered.
+Code-blocks under a size threshold are disregarded before analysis (the size
+threshold is controlled by \code{min_block_size}); and only top-level code
+blocks are considered.
 
-Every sufficiently large code block in the input files will be present in
+Every sufficiently large code-block in the input files will be present in
 the results at least once. If code-block X and code-block Y are present in
-a row of the resulting data-frame, then either X is the closest match to Y
+a row of the resulting data-frame, then either X is the closest match to Y,
 or Y is the closest match to X (or possibly both) according to the
-similarity score; as such some code blocks may be present multiple times in
+similarity score; as such, some code-blocks may be present multiple times in
 the results.
 
-Similarity between code blocks is calculated using the
+Similarity between code-blocks is calculated using the
 longest-common-subsequence (\code{lcs}) measure from the package
 \code{stringdist}. This measure is applied to a tokenised version of the
 code-blocks. That is, each function name / operator / variable in the code
-blocks is converted to a unique integer so that a code block can be
+blocks is converted to a unique integer so that a code-block can be
 represented as a vector of integers and the \code{lcs} measure is applied to
 each pair of these vectors.
 }
 \examples{
-# To quantify duplication between the top-level code blocks in a file
+# To quantify duplication between the top-level code-blocks in a file
 example_file <- system.file("extdata", "duplicated.R", package = "dupree")
 dup <- dupree(example_file, min_block_size = 10)
 dup
 
-# For the blocks with the highest duplication, we print the first four lines:
+# For the block-pair with the highest duplication, we print the first four
+# lines:
 readLines(example_file)[dup$line_a[1] + c(0:3)]
 readLines(example_file)[dup$line_b[1] + c(0:3)]
 
-# The code blocks in the example file are rather small, so if
-# `min_block_size` is too large, none of the code blocks will be analysed
+# The code-blocks in the example file are rather small, so if
+# `min_block_size` is too large, none of the code-blocks will be analysed
 # and the results will be empty:
 dupree(example_file, min_block_size = 40)
 

--- a/man/dupree_dir.Rd
+++ b/man/dupree_dir.Rd
@@ -32,3 +32,6 @@ well?}
 \description{
 `dupree_dir` - run duplicate-code detection over all R-files in a directory
 }
+\seealso{
+dupree
+}

--- a/man/dupree_package.Rd
+++ b/man/dupree_package.Rd
@@ -22,3 +22,6 @@ measurement.}
 `dupree_package` - run duplicate-code detection over all files in a
 package's `R` directory
 }
+\seealso{
+dupree
+}


### PR DESCRIPTION
An earlier commit had a mistake, where an '<AT>value' tag was used in
the roxygen2 for dupree(); this should have been an '<AT>return' tag.

Also
- increased the consistency of the documentation ('code-block' should be
used in the docs, not 'code block')
- exported the \seealso tags for `dupree_dir()` and `dupree_package()`