### PR TITLE
Class name linter

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -2,6 +2,10 @@ linters: with_defaults(
   commented_code_linter = NULL,
   line_length_linter(80),
   object_length_linter(40),
-  open_curly_linter = NULL,
-  spaces_left_parentheses_linter = NULL
+  object_name_linter(c("snake_case", "CamelCase")),
+  undesirable_function_linter = undesirable_function_linter(),
+  undesirable_operator_linter = undesirable_operator_linter()
+  )
+exclusions: list(
+  "inst/extdata/duplicated.R", "tests/testthat.R"
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dupree
 Type: Package
 Title: Identify Duplicated R Code in a Project
-Version: 0.2.0
+Version: 0.2.0.9000
 Author: Russ Hyde, University of Glasgow
 Maintainer: Russ Hyde <russ.hyde.data@gmail.com>
 Description: Identifies code blocks that have a high level of similarity

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# dupree (development version)
+
 # dupree 0.2.0
 
 * lintr dependence pinned to lintr=2.0.0 so that non-R-codeblocks and empty R

--- a/R/dupree.R
+++ b/R/dupree.R
@@ -152,9 +152,7 @@ dupree_dir <- function(path,
 
 dupree_package <- function(package,
                            min_block_size = 20) {
-  # nolint start
   dupree_dir(package, min_block_size, filter = paste0(package, "/R/"))
-  # nolint end
 }
 
 ###############################################################################

--- a/R/dupree_classes.R
+++ b/R/dupree_classes.R
@@ -54,10 +54,8 @@ methods::setValidity("EnumeratedCodeTable", .is_enumerated_code_table)
 methods::setMethod(
   "initialize",
   "EnumeratedCodeTable",
-  # nolint start
   function(.Object, blocks = NULL, ...) {
     .Object <- methods::callNextMethod(...)
-    # nolint end
 
     default_code_table <- tibble::tibble(
       file = character(0), block = integer(0), start_line = integer(0),


### PR DESCRIPTION
Update some linters:
- allow CamelCase class names
- disallow open curly's on their own line
- ensure a space before a left-paren (except for function calls)
- drop some undesirable functions / operators

Bump dev-version of the release number