### PR TITLE
[WIP] add script(s) to analyse lots of development packages using dupree

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,6 +7,7 @@
 ^\.travis\.yml$
 ^codecov\.yml$
 ^presentations$
+^random_scripts$
 ^appveyor\.yml$
 ^cran-comments.md$
 ^CRAN-RELEASE$

--- a/random_scripts/.gitignore
+++ b/random_scripts/.gitignore
@@ -1,0 +1,1 @@
+results

--- a/random_scripts/01-get-devtools-cran-table.R
+++ b/random_scripts/01-get-devtools-cran-table.R
@@ -61,7 +61,7 @@ import_dev_package_names <- function(url) {
 
 ###############################################################################
 
-run_script <- function(task_view_url, results_file, drop_pkgs = NULL) {
+main <- function(task_view_url, results_file, drop_pkgs = NULL) {
   # We identify packages that
   # - are currently on CRAN
   # - have a github URL
@@ -93,7 +93,7 @@ load_packages(
   c("dplyr", "janitor", "tibble", "magrittr", "readr", "xml2")
 )
 
-run_script(
+main(
   task_view_url = config[["task_view_url"]],
   results_file = config[["cran_details_file"]],
   drop_pkgs = config[["drop"]]

--- a/random_scripts/01-get-devtools-cran-table.R
+++ b/random_scripts/01-get-devtools-cran-table.R
@@ -54,35 +54,13 @@ import_dev_package_names <- function(url) {
 
 ###############################################################################
 
-define_repositories <- function(x) {
-  stop("TODO: define_repositories() function")
-  # Define a table containing package-name, remote-GH-url and
-  # local-repo-filepath (based on the filtered cran table)
-
-}
-
-clone_repositories <- function(x) {
-  stop("TODO: clone_packages() function")
-
-  # Clone each package from its remote to its local repo (but only if we
-  # haven't already cloned it)
-}
-
-###############################################################################
-
-run_script <- function(repo_dir, task_view_url) {
-  # download lots of CRAN packages from github
-  # the chosen packages relate to package development
-  # the repos will be stored in repo_dir
-  #
-  # we select packages that
+run_script <- function(task_view_url, results_dir) {
+  # We identify packages that
   # - are currently on CRAN
   # - have a github URL
   # - are mentioned on the ROpenSci software development task view
-  #
-  # we download repos using git2r
 
-  stopifnot(dir.exists(repo_dir))
+  stopifnot(dir.exists(results_dir))
 
   cran_gh <- import_github_cran_table()
   dev_packages <- import_dev_package_names(task_view_url)
@@ -91,29 +69,25 @@ run_script <- function(repo_dir, task_view_url) {
     cran_gh, Package %in% dev_packages
   )
 
-  repo_details <- define_repositories(dev_pkg_table)
-  clone_repositories(repo_details)
-
-  list(
+  readr::write_tsv(
     dev_pkg_table,
-    repo_details
+    file.path(results_dir, "dev-pkg-table.tsv")
   )
 }
 
 ###############################################################################
 
 # pkgs require for running the script (not the packages that are analysed here)
-load_packages(c("dplyr", "git2r", "tibble", "magrittr", "xml2"))
+load_packages(c("dplyr", "tibble", "magrittr", "readr", "xml2"))
 
-repo_dump <- normalizePath(
-  file.path("~", "temp", "dev-tools-analysis")
-)
+results_dir <- "results"
+
 task_view_url <- paste(
   "https://raw.githubusercontent.com/ropensci",
   "PackageDevelopment/master/PackageDevelopment.ctv",
   sep = "/"
 )
 
-run_script(repo_dump, task_view_url)
+run_script(task_view_url, results_dir)
 
 ###############################################################################

--- a/random_scripts/01-get-devtools-cran-table.R
+++ b/random_scripts/01-get-devtools-cran-table.R
@@ -61,11 +61,12 @@ import_dev_package_names <- function(url) {
 
 ###############################################################################
 
-run_script <- function(task_view_url, results_file) {
+run_script <- function(task_view_url, results_file, drop_pkgs = NULL) {
   # We identify packages that
   # - are currently on CRAN
   # - have a github URL
   # - are mentioned on the ROpenSci software development task view
+  # - are not in a set of packages for dropping from the pipeline (drop_pkgs)
 
   stopifnot(dir.exists(dirname(results_file)))
 
@@ -73,7 +74,8 @@ run_script <- function(task_view_url, results_file) {
   dev_packages <- import_dev_package_names(task_view_url)
 
   dev_pkg_table <- dplyr::filter(
-    cran_gh, package %in% dev_packages
+    cran_gh,
+    package %in% dev_packages & !package %in% drop_pkgs
   )
 
   readr::write_tsv(dev_pkg_table, results_file)
@@ -93,7 +95,8 @@ load_packages(
 
 run_script(
   task_view_url = config[["task_view_url"]],
-  results_file = config[["cran_details_file"]]
+  results_file = config[["cran_details_file"]],
+  drop_pkgs = config[["drop"]]
 )
 
 ###############################################################################

--- a/random_scripts/01-get-devtools-cran-table.R
+++ b/random_scripts/01-get-devtools-cran-table.R
@@ -1,15 +1,5 @@
 ###############################################################################
 
-load_packages <- function(pkgs) {
-  for (pkg in pkgs) {
-    suppressPackageStartupMessages(
-      library(pkg, character.only = TRUE)
-    )
-  }
-}
-
-###############################################################################
-
 contains_github <- function(x) {
   grepl("github\\.com", x)
 }
@@ -54,13 +44,13 @@ import_dev_package_names <- function(url) {
 
 ###############################################################################
 
-run_script <- function(task_view_url, results_dir) {
+run_script <- function(task_view_url, results_file) {
   # We identify packages that
   # - are currently on CRAN
   # - have a github URL
   # - are mentioned on the ROpenSci software development task view
 
-  stopifnot(dir.exists(results_dir))
+  stopifnot(dir.exists(dirname(results_file)))
 
   cran_gh <- import_github_cran_table()
   dev_packages <- import_dev_package_names(task_view_url)
@@ -69,25 +59,22 @@ run_script <- function(task_view_url, results_dir) {
     cran_gh, Package %in% dev_packages
   )
 
-  readr::write_tsv(
-    dev_pkg_table,
-    file.path(results_dir, "dev-pkg-table.tsv")
-  )
+  readr::write_tsv(dev_pkg_table, results_file)
 }
+
+###############################################################################
+
+source("utils.R")
+source("config.R")
 
 ###############################################################################
 
 # pkgs require for running the script (not the packages that are analysed here)
 load_packages(c("dplyr", "tibble", "magrittr", "readr", "xml2"))
 
-results_dir <- "results"
-
-task_view_url <- paste(
-  "https://raw.githubusercontent.com/ropensci",
-  "PackageDevelopment/master/PackageDevelopment.ctv",
-  sep = "/"
+run_script(
+  task_view_url = config[["task_view_url"]],
+  results_file = config[["cran_details_file"]]
 )
-
-run_script(task_view_url, results_dir)
 
 ###############################################################################

--- a/random_scripts/02-github-details.R
+++ b/random_scripts/02-github-details.R
@@ -1,15 +1,5 @@
 ###############################################################################
 
-load_packages <- function(pkgs) {
-  for (pkg in pkgs) {
-    suppressPackageStartupMessages(
-      library(pkg, character.only = TRUE)
-    )
-  }
-}
-
-###############################################################################
-
 define_repositories <- function(pkg_table, repo_dir) {
   stop("TODO: define_repositories() function")
   # Define a table containing package-name, remote-GH-url and
@@ -18,29 +8,31 @@ define_repositories <- function(pkg_table, repo_dir) {
 
 ###############################################################################
 
-run_script <- function(dev_pkgs_path, repo_dir, results_dir) {
+run_script <- function(cran_details_file, repo_dir, results_file) {
   # Converts a CRAN table that only contains github-hosted packages into a
   # table containing  (package-name, remote-repo, local-repo) paths.
 
-  dev_pkg_table <- readr::read_tsv(dev_pkgs_path)
+  dev_pkg_table <- readr::read_tsv(cran_details_file)
 
   repo_details <- define_repositories(dev_pkg_table, repo_dir)
 
-  readr::write_tsv(
-    repo_details,
-    file.path(results_dir, "dev-pkg-repositories.tsv")
-  )
+  readr::write_tsv(repo_details, results_file)
 }
 
 ###############################################################################
 
-# pkgs require for running the script (not the packages that are analysed here)
-load_packages(c("dplyr", "git2r", "tibble", "magrittr"))
+source("utils.R")
+source("config.R")
 
-results_dir <- "results"
+###############################################################################
+
+# pkgs require for running the script (not the packages that are analysed here)
+load_packages(c("dplyr", "magrittr", "readr", "tibble"))
+
 run_script(
-  file.path(results_dir, "dev-pkg-table.tsv"),
-  results_dir
+  cran_details_file = config[["cran_details_file"]],
+  repo_dir = config[["repo_dir"]],
+  results_file = config[["repo_details_file"]]
 )
 
 ###############################################################################

--- a/random_scripts/02-github-details.R
+++ b/random_scripts/02-github-details.R
@@ -1,18 +1,80 @@
 ###############################################################################
 
+get_repo_from_comma_sepd_string <- function(x) {
+  # input could be "http[s]://[www.]github.com/<user>/<repo>[/issues], some-other-url"
+
+  # For each entry in the vector of strings, return the first URL that is of
+  # the form
+  # "http[s]://[www.]github.com/<user>/repo[/<subdir>]"
+  # But strip off the optional <subdir> section (eg, issues)
+
+  stringr::str_extract(
+    string = x,
+    pattern = "(https*://(www\\.)*github.com/[^/]+/[^/]+)"
+  )
+}
+
+test_get_repo <- function() {
+  if (!requireNamespace("testthat")) {
+    message("testthat should be installed")
+    return()
+  }
+  testthat::test_that("repo_parser_works - single URLs", {
+    repo <- "github.com/abc/123"
+    ht <- c("https://", "http://")
+    www <- c("", "www.")
+    suffixes <- c("", "/", "/issues")
+
+    grid <- expand.grid(ht, www, repo, suffixes)
+    input_url <- do.call(paste0, grid)
+    expected_url <- do.call(paste0, grid[1:3])
+    testthat::expect_equal(
+      get_repo_from_comma_sepd_string(input_url),
+      expected_url
+    )
+  })
+}
+
 define_repositories <- function(pkg_table, repo_dir) {
-  stop("TODO: define_repositories() function")
   # Define a table containing package-name, remote-GH-url and
   # local-repo-filepath (based on the filtered cran table)
+
+  # URLs are stored as a ", "-separated string within fields 'url' and
+  # 'bug_reports'
+
+  define_remote <- function() {
+    get_repo_from_comma_sepd_string(
+      paste(pkg_table$url, pkg_table$bug_reports, sep = ", ")
+    )
+  }
+  define_local <- function() {
+    file.path(repo_dir, pkg_table$package)
+  }
+
+  tibble::tibble(
+    package = pkg_table$package,
+    remote_repo = define_remote(),
+    local_repo = define_local()
+  )
+}
+
+###############################################################################
+
+run_tests <- function() {
+  message("Running tests ...")
+  test_get_repo()
 }
 
 ###############################################################################
 
 run_script <- function(cran_details_file, repo_dir, results_file) {
+  message("Running script ...")
   # Converts a CRAN table that only contains github-hosted packages into a
   # table containing  (package-name, remote-repo, local-repo) paths.
 
-  dev_pkg_table <- readr::read_tsv(cran_details_file)
+  dev_pkg_table <- readr::read_tsv(
+    cran_details_file, col_types = cols(.default = "c")
+  )
 
   repo_details <- define_repositories(dev_pkg_table, repo_dir)
 
@@ -27,7 +89,9 @@ source("config.R")
 ###############################################################################
 
 # pkgs require for running the script (not the packages that are analysed here)
-load_packages(c("dplyr", "magrittr", "readr", "tibble"))
+load_packages(c("dplyr", "magrittr", "readr", "stringr", "tibble"))
+
+run_tests()
 
 run_script(
   cran_details_file = config[["cran_details_file"]],

--- a/random_scripts/02-github-details.R
+++ b/random_scripts/02-github-details.R
@@ -1,0 +1,46 @@
+###############################################################################
+
+load_packages <- function(pkgs) {
+  for (pkg in pkgs) {
+    suppressPackageStartupMessages(
+      library(pkg, character.only = TRUE)
+    )
+  }
+}
+
+###############################################################################
+
+define_repositories <- function(pkg_table, repo_dir) {
+  stop("TODO: define_repositories() function")
+  # Define a table containing package-name, remote-GH-url and
+  # local-repo-filepath (based on the filtered cran table)
+}
+
+###############################################################################
+
+run_script <- function(dev_pkgs_path, repo_dir, results_dir) {
+  # Converts a CRAN table that only contains github-hosted packages into a
+  # table containing  (package-name, remote-repo, local-repo) paths.
+
+  dev_pkg_table <- readr::read_tsv(dev_pkgs_path)
+
+  repo_details <- define_repositories(dev_pkg_table, repo_dir)
+
+  readr::write_tsv(
+    repo_details,
+    file.path(results_dir, "dev-pkg-repositories.tsv")
+  )
+}
+
+###############################################################################
+
+# pkgs require for running the script (not the packages that are analysed here)
+load_packages(c("dplyr", "git2r", "tibble", "magrittr"))
+
+results_dir <- "results"
+run_script(
+  file.path(results_dir, "dev-pkg-table.tsv"),
+  results_dir
+)
+
+###############################################################################

--- a/random_scripts/02-github-details.R
+++ b/random_scripts/02-github-details.R
@@ -90,7 +90,7 @@ run_tests <- function() {
 
 ###############################################################################
 
-run_script <- function(cran_details_file, repo_dir, results_file) {
+main <- function(cran_details_file, repo_dir, results_file) {
   message("Running script ...")
   # Converts a CRAN table that only contains github-hosted packages into a
   # table containing  (package-name, remote-repo, local-repo) paths.
@@ -116,7 +116,7 @@ load_packages(c("dplyr", "magrittr", "readr", "stringr", "tibble"))
 
 run_tests()
 
-run_script(
+main(
   cran_details_file = config[["cran_details_file"]],
   repo_dir = config[["repo_dir"]],
   results_file = config[["repo_details_file"]]

--- a/random_scripts/03-github-clone.R
+++ b/random_scripts/03-github-clone.R
@@ -5,10 +5,11 @@
 ###############################################################################
 
 clone_repositories <- function(x) {
-  stop("TODO: clone_repositories() function")
-
   # Clone each package from its remote to its local repo (but only if we
   # haven't already cloned it)
+  purrr::walk2(
+    x$remote_repo, x$local_repo, git2r::clone
+  )
 }
 
 ###############################################################################
@@ -22,7 +23,15 @@ run_script <- function(repo_details_file) {
     repo_details_file, col_types = readr::cols(.default = "c")
   )
 
-  clone_repositories(repo_details)
+  # Columns of `repo_details`:
+  # (package, remote_repo, local_repo)
+  stopifnot(
+    all(c("package", "remote_repo", "local_repo") %in% colnames(repo_details))
+  )
+
+  repo_details %>%
+    dplyr::filter(!dir.exists(local_repo)) %>%
+    clone_repositories()
 }
 
 ###############################################################################
@@ -33,7 +42,7 @@ source("config.R")
 ###############################################################################
 
 # pkgs require for running the script (not the packages that are analysed here)
-load_packages(c("dplyr", "git2r", "magrittr", "readr", "tibble"))
+load_packages(c("dplyr", "git2r", "magrittr", "purrr", "readr"))
 
 run_script(
   repo_details_file = config[["repo_details_file"]]

--- a/random_scripts/03-github-clone.R
+++ b/random_scripts/03-github-clone.R
@@ -14,7 +14,7 @@ clone_repositories <- function(x) {
 
 ###############################################################################
 
-run_script <- function(repo_details_file) {
+main <- function(repo_details_file) {
   # Takes a table of CRAN packages of the form (package-name, remote-repo,
   # local-repo) and clones each package from it's remote location to the
   # specified local location.
@@ -44,7 +44,7 @@ source("config.R")
 # pkgs require for running the script (not the packages that are analysed here)
 load_packages(c("dplyr", "git2r", "magrittr", "purrr", "readr"))
 
-run_script(
+main(
   repo_details_file = config[["repo_details_file"]]
 )
 

--- a/random_scripts/03-github-clone.R
+++ b/random_scripts/03-github-clone.R
@@ -4,18 +4,8 @@
 
 ###############################################################################
 
-load_packages <- function(pkgs) {
-  for (pkg in pkgs) {
-    suppressPackageStartupMessages(
-      library(pkg, character.only = TRUE)
-    )
-  }
-}
-
-###############################################################################
-
 clone_repositories <- function(x) {
-  stop("TODO: clone_packages() function")
+  stop("TODO: clone_repositories() function")
 
   # Clone each package from its remote to its local repo (but only if we
   # haven't already cloned it)
@@ -28,18 +18,25 @@ run_script <- function(repo_details_file) {
   # local-repo) and clones each package from it's remote location to the
   # specified local location.
 
-  repo_details <- readr::read_tsv(repo_details_file)
+  repo_details <- readr::read_tsv(
+    repo_details_file, col_types = readr::cols(.default = "c")
+  )
 
   clone_repositories(repo_details)
 }
 
 ###############################################################################
 
+source("utils.R")
+source("config.R")
+
+###############################################################################
+
 # pkgs require for running the script (not the packages that are analysed here)
 load_packages(c("dplyr", "git2r", "magrittr", "readr", "tibble"))
 
-repo_details_file <- file.path("results", "dev-pkg-repositories.tsv")
-
-run_script(repo_details_file)
+run_script(
+  repo_details_file = config[["repo_details_file"]]
+)
 
 ###############################################################################

--- a/random_scripts/03-github-clone.R
+++ b/random_scripts/03-github-clone.R
@@ -1,0 +1,45 @@
+###############################################################################
+
+# Download lots of R packages from remote to local repositories
+
+###############################################################################
+
+load_packages <- function(pkgs) {
+  for (pkg in pkgs) {
+    suppressPackageStartupMessages(
+      library(pkg, character.only = TRUE)
+    )
+  }
+}
+
+###############################################################################
+
+clone_repositories <- function(x) {
+  stop("TODO: clone_packages() function")
+
+  # Clone each package from its remote to its local repo (but only if we
+  # haven't already cloned it)
+}
+
+###############################################################################
+
+run_script <- function(repo_details_file) {
+  # Takes a table of CRAN packages of the form (package-name, remote-repo,
+  # local-repo) and clones each package from it's remote location to the
+  # specified local location.
+
+  repo_details <- readr::read_tsv(repo_details_file)
+
+  clone_repositories(repo_details)
+}
+
+###############################################################################
+
+# pkgs require for running the script (not the packages that are analysed here)
+load_packages(c("dplyr", "git2r", "magrittr", "readr", "tibble"))
+
+repo_details_file <- file.path("results", "dev-pkg-repositories.tsv")
+
+run_script(repo_details_file)
+
+###############################################################################

--- a/random_scripts/04-dupree-analysis.R
+++ b/random_scripts/04-dupree-analysis.R
@@ -111,7 +111,7 @@ load_packages(
 
 main(
   repo_details_file = config[["repo_details_file"]],
-  results_dir = config[["results_dir"]],
+  results_dir = config[["pkg_results_dir"]],
   min_block_sizes = config[["min_block_sizes"]]
 )
 

--- a/random_scripts/04-dupree-analysis.R
+++ b/random_scripts/04-dupree-analysis.R
@@ -12,7 +12,7 @@ run_benchmark_workflow <- function(local_repo, results_file, min_block_sizes) {
   # Error in stream_delim_(df, path, ..., bom = bom, quote_escape =
   # quote_escape) :
   # Don't know how to handle vector of type list.
-  # Calls: run_script ... <Anonymous> -> write_delim -> stream_delim ->
+  # Calls: main ... <Anonymous> -> write_delim -> stream_delim ->
   # stream_delim_
   # In addition: There were 50 or more warnings (use warnings() to see the
   # first 50)
@@ -71,7 +71,7 @@ run_workflow <- function(package, local_repo, results_dir, min_block_sizes) {
 
 # --
 
-run_script <- function(repo_details_file, results_dir, min_block_sizes) {
+main <- function(repo_details_file, results_dir, min_block_sizes) {
 
   repo_details <- readr::read_tsv(
     repo_details_file, col_types = readr::cols(.default = "c")
@@ -109,7 +109,7 @@ load_packages(
   c("bench", "dplyr", "dupree", "git2r", "magrittr", "readr", "tibble")
 )
 
-run_script(
+main(
   repo_details_file = config[["repo_details_file"]],
   results_dir = config[["results_dir"]],
   min_block_sizes = config[["min_block_sizes"]]

--- a/random_scripts/04-dupree-analysis.R
+++ b/random_scripts/04-dupree-analysis.R
@@ -1,19 +1,100 @@
 ###############################################################################
 
-run_script <- function(repo_details_file) {
+run_benchmark_workflow <- function(local_repo, results_file, min_block_sizes) {
+  #  TODO: fix this error in the benchmark calls
+  #   - it appears to be due to calling `write_tsv` on a benchmark tibble
+  # --
+  # Running dupree workflow for: aoos
+  # Running with:
+  #   min_block_size
+  # 1            100
+  # 2             40
+  # Error in stream_delim_(df, path, ..., bom = bom, quote_escape =
+  # quote_escape) :
+  # Don't know how to handle vector of type list.
+  # Calls: run_script ... <Anonymous> -> write_delim -> stream_delim ->
+  # stream_delim_
+  # In addition: There were 50 or more warnings (use warnings() to see the
+  # first 50)
+  # Execution halted
+  # --
+
+  # Time the running of dupree over a package and save the timings to an .RDS
+  # file
+  results <- bench::press(
+    min_block_size = min_block_sizes, {
+      bench::mark(
+        min_iterations = 5,
+        dups = dupree::dupree_package(
+          local_repo, min_block_size = min_block_size
+        )
+      )
+    }
+  )
+  readr::write_rds(results, results_file)
+}
+
+run_dupree_workflow <- function(local_repo, results_file, min_block_size) {
+  dups <- dupree::dupree_package(local_repo, min_block_size)
+  readr::write_tsv(dups, results_file)
+}
+
+# --
+
+run_workflow <- function(package, local_repo, results_dir, min_block_sizes) {
+  message("Running dupree workflow for: ", package)
+
+  pkg_results_dir <- file.path(results_dir, package)
+  dir.create(pkg_results_dir)
+
+  # -- obtain / save the duplicated code-block results
+  #
+  # This fails if no top-level ./R/ directory is found
+  #
+  for (bs in min_block_sizes) {
+    results_file <- file.path(
+      pkg_results_dir, paste0("dupree_table.b", bs, ".tsv")
+    )
+    if (! file.exists(results_file)) {
+      run_dupree_workflow(local_repo, results_file, bs)
+    }
+  }
+
+  # -- obtain timings for creating the duplicated code-block results
+  bench_results_file <- file.path(
+    pkg_results_dir, "dupree_timings.rds"
+  )
+  if (! file.exists(bench_results_file)) {
+    run_benchmark_workflow(local_repo, bench_results_file, min_block_sizes)
+  }
+}
+
+# --
+
+run_script <- function(repo_details_file, results_dir, min_block_sizes) {
+
   repo_details <- readr::read_tsv(
     repo_details_file, col_types = readr::cols(.default = "c")
   )
 
   # For each repo,
-  # For each min_block_size in (10, 20, 40, 100)
+  # For each min_block_size in some set
   # - Run dupree
   # - Save the results table to a file
+  #     - <results_dir>/<package_name>/dupree_table.b<block_size>.tsv
   # - Measure the time it takes to run & save (package, min_block_size,
   # time_taken) to a file
+  #     - <results_dir>/<package_name>/dupree_timings.tsv
   # - Suggest saving the timings in bench::mark results format
 
-  stop("TODO: implement run_script for 04-dupree-analysis.R")
+  for (i in seq_len(nrow(repo_details))) {
+    run_workflow(
+      repo_details$package[i],
+      repo_details$local_repo[i],
+      results_dir,
+      min_block_sizes
+    )
+  }
 }
 
 ###############################################################################
@@ -24,10 +105,14 @@ source("config.R")
 ###############################################################################
 
 # pkgs require for running the script (not the packages that are analysed here)
-load_packages(c("dplyr", "git2r", "magrittr", "readr", "tibble"))
+load_packages(
+  c("bench", "dplyr", "dupree", "git2r", "magrittr", "readr", "tibble")
+)
 
 run_script(
-  repo_details_file = config[["repo_details_file"]]
+  repo_details_file = config[["repo_details_file"]],
+  results_dir = config[["results_dir"]],
+  min_block_sizes = config[["min_block_sizes"]]
 )
 
 ###############################################################################

--- a/random_scripts/04-dupree-analysis.R
+++ b/random_scripts/04-dupree-analysis.R
@@ -1,0 +1,33 @@
+###############################################################################
+
+run_script <- function(repo_details_file) {
+  repo_details <- readr::read_tsv(
+    repo_details_file, col_types = readr::cols(.default = "c")
+  )
+
+  # For each repo,
+  # For each min_block_size in (10, 20, 40, 100)
+  # - Run dupree
+  # - Save the results table to a file
+  # - Measure the time it takes to run & save (package, min_block_size,
+  # time_taken) to a file
+  # - Suggest saving the timings in bench::mark results format
+
+  stop("TODO: implement run_script for 04-dupree-analysis.R")
+}
+
+###############################################################################
+
+source("utils.R")
+source("config.R")
+
+###############################################################################
+
+# pkgs require for running the script (not the packages that are analysed here)
+load_packages(c("dplyr", "git2r", "magrittr", "readr", "tibble"))
+
+run_script(
+  repo_details_file = config[["repo_details_file"]]
+)
+
+###############################################################################

--- a/random_scripts/05-collapse-benchmarks.R
+++ b/random_scripts/05-collapse-benchmarks.R
@@ -1,0 +1,81 @@
+###############################################################################
+
+define_pkg_timings_paths <- function(packages, pkg_results_dir) {
+  tibble(
+    package = packages,
+    path = file.path(pkg_results_dir, package, "dupree_timings.rds")
+  )
+}
+
+###############################################################################
+
+format_benchmark <- function(table) {
+  list_cols <- which(map_lgl(table, is.list))
+  table[, list_cols] <- NA
+  as_tibble(table)
+}
+
+collapse_benchmarks <- function(tables) {
+  # should be a named list of bench::press result tables
+  stopifnot(is.list(tables) && !is.null(names(tables)))
+  map_df(tables, format_benchmark, .id = "package")
+}
+
+###############################################################################
+
+# --
+
+main <- function(
+    repo_details_file, results_dir, pkg_results_dir, output_file
+) {
+  repo_details <- readr::read_tsv(
+    repo_details_file, col_types = readr::cols(.default = "c")
+  )
+
+  # For each repo, there is a .rds file containing bench::press results
+  # 
+  # Combine these results into a single table
+  
+  pkg_timings_paths <- define_pkg_timings_paths(
+    repo_details[["package"]], pkg_results_dir
+  )
+
+  bench_results <- Map(
+    function(pkg, path) read_rds(path),
+    pkg_timings_paths[["package"]],
+    pkg_timings_paths[["path"]]
+  )
+  
+  # Combine the benchmark data for each package into a single table
+  # - we suppress the `Vectorizing 'bench_time' ...` warnings
+  summarised_results <- suppressWarnings(
+    collapse_benchmarks(bench_results)
+  )
+
+  readr::write_tsv(summarised_results, output_file)
+}
+
+###############################################################################
+
+source("utils.R")
+source("config.R")
+
+###############################################################################
+
+# pkgs require for running the script (not the packages that are analysed here)
+load_packages(
+  c("bench", "dplyr", "magrittr", "purrr", "readr", "tibble")
+)
+
+main(
+  repo_details_file = config[["repo_details_file"]],
+  results_dir = config[["results_dir"]],
+  pkg_results_dir = config[["pkg_results_dir"]],
+  output_file = config[["all_pkg_benchmarks_file"]]
+)
+
+# 
+# ggplot(df, aes(x = median, y = factor(package, levels =
+#   unique(package[order(median)])))) + geom_point(aes(col = min_block_size))
+
+###############################################################################

--- a/random_scripts/analyse-development-tools.R
+++ b/random_scripts/analyse-development-tools.R
@@ -1,0 +1,119 @@
+###############################################################################
+
+load_packages <- function(pkgs) {
+  for (pkg in pkgs) {
+    suppressPackageStartupMessages(
+      library(pkg, character.only = TRUE)
+    )
+  }
+}
+
+###############################################################################
+
+contains_github <- function(x) {
+  grepl("github\\.com", x)
+}
+
+format_cran_table <- function(x) {
+  tibble::as_tibble(x[, !duplicated(colnames(x))])
+}
+
+import_github_cran_table <- function() {
+  # code modified from https://juliasilge.com/blog/mining-cran-description/
+
+  # Download a table containing all the DESCRIPTION fields for the packages on
+  # CRAN
+  # - then remove duplicated fields
+  # - turn it into a tibble
+  # - and filter to keep only packages that have a github repo
+
+  # read
+  raw_cran <- tools::CRAN_package_db()
+
+  # format & restrict to github repos
+  format_cran_table(raw_cran) %>%
+    dplyr::filter(contains_github(URL) | contains_github(BugReports))
+}
+
+###############################################################################
+
+extract_package_names <- function(xml) {
+  # package names are each stored in a <pkg> tag on the task view page
+  # and the list of <pkg> tags is stored in a <packagelist> tag
+
+  # extract the package names
+  xml %>%
+    xml2::xml_find_all("packagelist/pkg") %>%
+    xml2::xml_text()
+}
+
+import_dev_package_names <- function(url) {
+  xml2::read_xml(url) %>%
+    extract_package_names()
+}
+
+###############################################################################
+
+define_repositories <- function(x) {
+  stop("TODO: define_repositories() function")
+  # Define a table containing package-name, remote-GH-url and
+  # local-repo-filepath (based on the filtered cran table)
+
+}
+
+clone_repositories <- function(x) {
+  stop("TODO: clone_packages() function")
+
+  # Clone each package from its remote to its local repo (but only if we
+  # haven't already cloned it)
+}
+
+###############################################################################
+
+run_script <- function(repo_dir, task_view_url) {
+  # download lots of CRAN packages from github
+  # the chosen packages relate to package development
+  # the repos will be stored in repo_dir
+  #
+  # we select packages that
+  # - are currently on CRAN
+  # - have a github URL
+  # - are mentioned on the ROpenSci software development task view
+  #
+  # we download repos using git2r
+
+  stopifnot(dir.exists(repo_dir))
+
+  cran_gh <- import_github_cran_table()
+  dev_packages <- import_dev_package_names(task_view_url)
+
+  dev_pkg_table <- dplyr::filter(
+    cran_gh, Package %in% dev_packages
+  )
+
+  repo_details <- define_repositories(dev_pkg_table)
+  clone_repositories(repo_details)
+
+  list(
+    dev_pkg_table,
+    repo_details
+  )
+}
+
+###############################################################################
+
+# pkgs require for running the script (not the packages that are analysed here)
+load_packages(c("dplyr", "git2r", "tibble", "magrittr", "xml2"))
+
+repo_dump <- normalizePath(
+  file.path("~", "temp", "dev-tools-analysis")
+)
+task_view_url <- paste(
+  "https://raw.githubusercontent.com/ropensci",
+  "PackageDevelopment/master/PackageDevelopment.ctv",
+  sep = "/"
+)
+
+run_script(repo_dump, task_view_url)
+
+###############################################################################

--- a/random_scripts/config.R
+++ b/random_scripts/config.R
@@ -38,6 +38,9 @@ config <- append(
     ),
     cran_details_file = file.path(
       config[["results_dir"]], "dev-pkg-table.tsv"
+    ),
+    all_pkg_benchmarks_file = file.path(
+      config[["results_dir"]], "dev-pkg-benchmarks.tsv"
     )
   )
 )

--- a/random_scripts/config.R
+++ b/random_scripts/config.R
@@ -1,0 +1,33 @@
+###############################################################################
+
+# Config details for the analysis of development tools packages using {dupree}
+# - filepaths etc
+
+###############################################################################
+
+config <- list(
+  results_dir = file.path("results"),
+  repo_dir = normalizePath(
+    file.path("~", "temp", "dev-tools-analysis"),
+    mustWork = FALSE
+  ),
+  task_view_url = paste(
+    "https://raw.githubusercontent.com/ropensci",
+    "PackageDevelopment/master/PackageDevelopment.ctv",
+    sep = "/"
+  )
+)
+
+config <- append(
+  config,
+  list(
+    repo_details_file = file.path(
+      config[["results_dir"]], "dev-pkg-respositories.tsv"
+    ),
+    cran_details_file = file.path(
+      config[["results_dir"]], "dev-pkg-table.tsv"
+    )
+  )
+)
+
+###############################################################################

--- a/random_scripts/config.R
+++ b/random_scripts/config.R
@@ -6,17 +6,25 @@
 ###############################################################################
 
 config <- list(
+  # Store results summaries here:
   results_dir = file.path("results"),
+
+  # Store results for individual packages in subdirs of this:
+  pkg_results_dir = file.path("results", "packages"),
+
   repo_dir = normalizePath(
     file.path("~", "temp", "dev-tools-analysis"),
     mustWork = FALSE
   ),
+
   task_view_url = paste(
     "https://raw.githubusercontent.com/ropensci",
     "PackageDevelopment/master/PackageDevelopment.ctv",
     sep = "/"
   ),
+
   min_block_sizes = c(100, 40), #, 20, 10)
+
   # The github repo for package `logging` does not conform to standard R
   # package structure, and causes dupree to fail.
   drop = "logging"

--- a/random_scripts/config.R
+++ b/random_scripts/config.R
@@ -15,7 +15,11 @@ config <- list(
     "https://raw.githubusercontent.com/ropensci",
     "PackageDevelopment/master/PackageDevelopment.ctv",
     sep = "/"
-  )
+  ),
+  min_block_sizes = c(100, 40), #, 20, 10)
+  # The github repo for package `logging` does not conform to standard R
+  # package structure, and causes dupree to fail.
+  drop = "logging"
 )
 
 config <- append(

--- a/random_scripts/utils.R
+++ b/random_scripts/utils.R
@@ -1,0 +1,11 @@
+###############################################################################
+
+load_packages <- function(pkgs) {
+  for (pkg in pkgs) {
+    suppressPackageStartupMessages(
+      library(pkg, character.only = TRUE)
+    )
+  }
+}
+
+###############################################################################


### PR DESCRIPTION
Plan:
- Download DESCRIPTION data for all packages at CRAN
- Extract the names for a set of package-development tools from ROpenSci
- Restrict to get package-development tools that are hosted on github
and which are available at CRAN
- Clone the repository for each of these packages
- Run dupree, pkgnet and a variety of other package analysis tools over
the set of repositories