### PR TITLE
fix #57: assert R pkg structure in `dupree_package`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     rlang
 RoxygenNote: 6.1.1
 Collate:
+    'utils.R'
     'dupree.R'
     'dupree_classes.R'
     'dupree_data_validity.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dupree (development version)
 
+* `dupree_package()` asserts that a path has a DESCRIPTION and an R/ subdir
+  present (#57, @russHyde)
+
 # dupree 0.2.0
 
 * lintr dependence pinned to lintr=2.0.0 so that non-R-codeblocks and empty R

--- a/R/dupree.R
+++ b/R/dupree.R
@@ -87,7 +87,6 @@
 #' # `min_block_size` is too large, none of the code-blocks will be analysed
 #' # and the results will be empty:
 #' dupree(example_file, min_block_size = 40)
-#'
 #' @export
 
 dupree <- function(files, min_block_size = 20, ...) {
@@ -142,6 +141,9 @@ dupree_dir <- function(path = ".",
 #' Run duplicate-code detection over all files in the `R` directory of a
 #' package
 #'
+#' The function fails if the path does not look like a typical R package (it
+#' should have both an R/ subdirectory and a DESCRIPTION file present).
+#'
 #' @inheritParams   dupree
 #'
 #' @param        package       The name or path to the package that is to be
@@ -149,10 +151,17 @@ dupree_dir <- function(path = ".",
 #'
 #' @seealso      dupree
 #'
+#' @include      utils.R
 #' @export
 
 dupree_package <- function(package = ".",
                            min_block_size = 20) {
+  if (!has_description(package)) {
+    stop("The path ", package, "is not an R package (no DESCRIPTION)")
+  }
+  if (!has_r_source_dir(package)) {
+    stop("The path", package, "is not an R package (no R/ subdir)")
+  }
   dupree_dir(package, min_block_size, filter = paste0(package, "/R/"))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,7 @@
+has_description <- function(path) {
+  file.exists(file.path(path, "DESCRIPTION"))
+}
+
+has_r_source_dir <- function(path) {
+  dir.exists(file.path(path, "R"))
+}

--- a/man/dupree_package.Rd
+++ b/man/dupree_package.Rd
@@ -19,8 +19,8 @@ symbols from each code-block, only those blocks containing at least
 measurement.}
 }
 \description{
-Run duplicate-code detection over all files in the `R` directory of a
-package
+The function fails if the path does not look like a typical R package (it
+should have both an R/ subdirectory and a DESCRIPTION file present).
 }
 \seealso{
 dupree

--- a/tests/testthat/test-dupree_package_integration.R
+++ b/tests/testthat/test-dupree_package_integration.R
@@ -1,6 +1,6 @@
 context("Integration tests for `dupree_package()`")
 
-test_that("Only files in <my_pkg>/R/ are present in the results", {
+test_that("`dupree_package` results only include files from <my_pkg>/R/", {
   # the test-package "anRpackage" contains
   # - ./R/anRpackage-internal.R
   # - and ./inst/dir1/R/dont_dup_me.R
@@ -14,5 +14,30 @@ test_that("Only files in <my_pkg>/R/ are present in the results", {
   expect_equal(
     files,
     file.path("testdata", "anRpackage", "R", "anRpackage-internal.R")
+  )
+})
+
+test_that("`dupree_package` fails when passed a non-R package structure", {
+
+  # There must be a DESCRIPTION file present
+  d <- tempfile(pattern = "not_an_r_package")
+  dir.create(d)
+  dir.create(file.path(d, "R"))
+
+  expect_error(
+    dupree_package(d),
+    regexp = "not an R package",
+    info = "DESCRIPTION must be present in the path passed to dupree_package"
+  )
+
+  # There must be an R/ subdirectory present
+  d <- tempfile(pattern = "not_an_r_package")
+  dir.create(d)
+  file.create(file.path(d, "DESCRIPTION"))
+
+  expect_error(
+    dupree_package(d),
+    regexp = "not an R package",
+    info = "R/ subdir must be present in the path passed to dupree_package"
   )
 })


### PR DESCRIPTION
`dupree_package` now checks that a given path contains

- a DESCRIPTION
- an R/ subdirectory

Utility functions were added to `utils.R` and integration tests on
package structure were added.