### PR TITLE
rewrite function to compare two list-containing tibbles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,7 @@ LazyData: true
 Suggests:
     testthat (>= 2.1.0),
     knitr,
-    rmarkdown,
-    tidyr
+    rmarkdown
 Imports:
     dplyr,
     purrr,

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,13 +1,32 @@
 #' Since you can't compare two `tbl_df` objects when they contain a list as a
 #' column using expect_equal or all.equal
 #'
-#' @importFrom   tidyr         unnest
-#'
-expect_equal_listy_tbl <- function(object, expected, ...) {
-  expect_equal(
-    object = tidyr::unnest(object),
-    expected = tidyr::unnest(expected),
-    ...
+expect_equal_tbl <- function(object, expected, ..., info = NULL) {
+  act <- testthat::quasi_label(rlang::enquo(object), arg = "object")
+  exp <- testthat::quasi_label(rlang::enquo(expected), arg = "expected")
+
+  # all.equal.list is slightly problematic: it returns TRUE for match, and
+  # returns a character vector when differences are observed. We extract
+  # both a match-indicator and a failure message
+
+  diffs <- all.equal.list(object, expected, ...)
+  has_diff <- if (is.logical(diffs)) diffs else FALSE
+  diff_msg <- paste(diffs, collapse = "\n")
+
+  testthat::expect(
+    has_diff,
+    failure_message = sprintf(
+      "%s not equal to %s.\n%s", act$lab, exp$lab, diff_msg
+    ),
+    info = info
+  )
+
+  invisible(act$val)
+}
+
+expect_equivalent_tbl <- function(object, expected, ..., info = NULL) {
+  expect_equal_tbl(
+    object, expected, ..., check.attributes = FALSE, info = info
   )
 }
 

--- a/tests/testthat/test_dupree_classes.R
+++ b/tests/testthat/test_dupree_classes.R
@@ -30,7 +30,7 @@ test_that("EnumeratedCodeTable: construction / validity", {
     enumerated_code = list()
   )
 
-  expect_equal_listy_tbl(
+  expect_equal_tbl(
     new("EnumeratedCodeTable")@blocks,
     default_blocks,
     info = paste(
@@ -46,7 +46,7 @@ test_that("EnumeratedCodeTable: construction / validity", {
     enumerated_code = list(as.integer(c(1, 2, 3, 4, 5)))
   )
 
-  expect_equal_listy_tbl(
+  expect_equal_tbl(
     new("EnumeratedCodeTable", my_blocks)@blocks,
     my_blocks,
     info = paste(

--- a/tests/testthat/test_dupree_code_enumeration.R
+++ b/tests/testthat/test_dupree_code_enumeration.R
@@ -125,7 +125,8 @@ test_that("summarise_enumerated_blocks", {
     file = "some/file.R", block = 1L, start_line = 1L,
     enumerated_code = list(c(60L)), block_size = 1L
   )
-  expect_equal_listy_tbl(
+  # some attribute differences may be expected
+  expect_equivalent_tbl(
     object = summarise_enumerated_blocks(input),
     expected = expected,
     info = "block with a single code symbol"


### PR DESCRIPTION
New function is called `expect_equal_tbl` (rather than
`expect_equal_listy_tbl`, as previously).

One of my tests failed when using the release-pending dplyr=1.0 (and
similarly updated rlang, vctrs): the earlier versions of dplyr (etc)
allowed attribute mismatches between list-containing tbls but the new
dplyr don't (when using tidyr::unnest and then comparing dataframes).

The test has been rewritten based on one of my stack overflow posts:
https://stackoverflow.com/a/59947803/1845650

... and no longer needs tidyr

I have added a `expect_equivalent_tbl` function too, this allows
attribute mismatches when comparing two list-containing tbls.