### PR TITLE
drop R-3.3 and R-3.2 from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,3 @@ matrix:
     - Rscript -e 'covr::codecov()'
   - r: oldrel
   - r: 3.4
-  - r: 3.3
-  - r: 3.2


### PR DESCRIPTION
Could not install Rcpp on Travis with these R builds. So dupree appeared
to be failing.