### PR TITLE
Pass dots to the tibble print method

### DIFF
--- a/R/dups-class.R
+++ b/R/dups-class.R
@@ -46,7 +46,7 @@ tibble::as_tibble
 
 # nocov start
 print.dups <- function(x, ...) {
-  print(as_tibble(x))
+  print(as_tibble(x), ...)
   invisible(x)
 }
 # nocov end


### PR DESCRIPTION
Howdy! I'd like to propose a small tweak to the dups print method, to let people pass arguments via `...` to the tibble print method. My use-case is to print out tables with > 10 rows, which get truncated by print.tibble(). In that situation, it'd be nice to pass `n` to the tibble print method via `...`.